### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Error: Use JavaScript happiness Style
 ### Editor plugins
 
 - **Sublime users**: Try [SublimeLinter-contrib-happiness](https://github.com/JedWatson/SublimeLinter-contrib-happiness) for linting in your editor!
-- **Atom users** - Install [Linter](https://atom.io/packages/linter) and [linter-js-standard](https://atom.io/packages/linter-js-standard) (don't you mind with the misleading name it supports both styles).
+- **Atom users** - Install [linter-js-standard](https://atom.io/packages/linter-js-standard) (don't you mind with the misleading name it supports both styles).
 
 
 ### What you might do if you're clever


### PR DESCRIPTION
`linter-js-standard` doesn't need `linter` installed beforehand as prior. [`59cbc84`](https://github.com/ricardofbarros/linter-js-standard/commit/59cbc84b6e2eb9ab3ec9aac50b77ff23d4d8c9a3)
