### PR TITLE
fixed the badge urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 [![npm][npm-image]][npm-url]
 [![downloads][downloads-image]][downloads-url]
 
-[travis-image]: https://travis-ci.org/feross/standard.svg?branch=master
-[travis-url]: https://travis-ci.org/feross/standard
-[npm-image]: https://img.shields.io/npm/v/standard.svg?style=flat
-[npm-url]: https://npmjs.org/package/standard
-[downloads-image]: https://img.shields.io/npm/dm/standard.svg?style=flat
-[downloads-url]: https://npmjs.org/package/standard
+[travis-image]: https://travis-ci.org/JedWatson/happiness.svg?branch=master
+[travis-url]: https://travis-ci.org/JedWatson/happiness
+[npm-image]: https://img.shields.io/npm/v/happiness.svg?style=flat
+[npm-url]: https://npmjs.org/package/happiness
+[downloads-image]: https://img.shields.io/npm/dm/happiness.svg?style=flat
+[downloads-url]: https://npmjs.org/package/happiness
 
 [Standard](https://github.com/feross/standard) customised to make [me](http://github.com/JedWatson/) happy.
 


### PR DESCRIPTION
Didn't notice until looking at it on npm, but the badges were still pointing to standard.  Seemed like the travis and download counts would be good to have.  @dcousens @JedWatson any objections?  

Also, this really doesn't require a publish, we can just push it out when the next version of standard goes out, but at least it will be correct on the github page.
