### PR TITLE
update eslint-config-standard to 5.1.0

### DIFF
--- a/options.js
+++ b/options.js
@@ -1,3 +1,4 @@
+var eslint = require('eslint');
 var path = require('path');
 var pkg = require('./package.json');
 
@@ -6,6 +7,7 @@ module.exports = {
 	version: pkg.version,
 	homepage: pkg.homepage,
 	bugs: pkg.bugs.url,
+	eslint: eslint,
 	tagline: 'Use JavaScript Happiness Style',
 	eslintConfig: {
 		configFile: path.join(__dirname, 'rc', '.eslintrc')

--- a/package.json
+++ b/package.json
@@ -7,13 +7,17 @@
     "name": "Feross Aboukhadijeh",
     "url": "http://feross.org/"
   },
-  "contributors": [{
-    "name": "Jed Watson"
-  }, {
-    "name": "Daniel Cousens"
-  }, {
-    "name": "Wes Todd"
-  }],
+  "contributors": [
+    {
+      "name": "Jed Watson"
+    },
+    {
+      "name": "Daniel Cousens"
+    },
+    {
+      "name": "Wes Todd"
+    }
+  ],
   "bin": {
     "happiness": "./bin/cmd.js"
   },
@@ -21,12 +25,12 @@
     "url": "https://github.com/JedWatson/happiness/issues"
   },
   "dependencies": {
-    "eslint-config-standard": "4.4.0",
+    "eslint-config-standard": "^5.1.0",
     "eslint-config-standard-react": "1.2.1",
     "eslint-plugin-react": "^3.9.0",
     "eslint-plugin-standard": "^1.3.1",
-    "standard-engine": "^2.0.4",
-    "happiness-format": "^1.1.0"
+    "happiness-format": "^1.1.0",
+    "standard-engine": "^2.0.4"
   },
   "devDependencies": {
     "mkdirp": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -25,12 +25,14 @@
     "url": "https://github.com/JedWatson/happiness/issues"
   },
   "dependencies": {
+    "eslint": "^2.2.0",
     "eslint-config-standard": "^5.1.0",
     "eslint-config-standard-react": "1.2.1",
+    "eslint-plugin-promise": "^1.0.8",
     "eslint-plugin-react": "^3.9.0",
     "eslint-plugin-standard": "^1.3.1",
     "happiness-format": "^1.1.0",
-    "standard-engine": "^2.0.4"
+    "standard-engine": "^3.3.0"
   },
   "devDependencies": {
     "mkdirp": "^0.5.0",

--- a/test/clone.js
+++ b/test/clone.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#! /usr/bin/env node
 
 /**
  * Clones several projects that are known to follow "JavaScript Standard Style" and runs

--- a/test/clone.js
+++ b/test/clone.js
@@ -1,4 +1,4 @@
-#! /usr/bin/env node
+// #!/usr/bin/env node
 
 /**
  * Clones several projects that are known to follow "JavaScript Standard Style" and runs


### PR DESCRIPTION
The changes in the `contributors` lines and the swapping of `standard-engine` and `happiness-format` were automatically done by npm. I'm not sure if that's acceptable. I could remove those changes if that's more desirable.

cc/ wesleytodd
