### PR TITLE
use tabs for jsx

### DIFF
--- a/rc/.eslintrc.json
+++ b/rc/.eslintrc.json
@@ -2,6 +2,8 @@
   "rules": {
     "indent": [2, "tab"],
     "jsx-quotes": [2, "prefer-double"],
+    "react/jsx-indent": [2, "tab"],
+    "react/jsx-indent-props": [2, "tab"],
     "no-extra-semi": 2,
     "semi": [2, "always"],
     "semi-spacing": [2, { "before": false, "after": true }]


### PR DESCRIPTION
This allows for the use of tabs on JSX files.

Also, while adding this fix, I saw the `jsx-quotes` property, but I don't see it anywhere here https://github.com/feross/eslint-config-standard-jsx/blob/master/eslintrc.json. Would it be a deprecated property?
