### PR TITLE
Updated options.js to use babel-eslint parser

### DIFF
--- a/options.js
+++ b/options.js
@@ -8,7 +8,7 @@ module.exports = {
 	eslint: eslint,
 	eslintConfig: {
 		configFile: path.join(__dirname, 'eslintrc.json'),
-		parser: "babel-eslint"
+		parser: 'babel-eslint'
 	},
 	formatter: 'Formatting is no longer included with standard. Install it separately: "npm install -g happiness-format"',
 	homepage: pkg.homepage,

--- a/options.js
+++ b/options.js
@@ -7,7 +7,8 @@ module.exports = {
 	cmd: 'happiness',
 	eslint: eslint,
 	eslintConfig: {
-		configFile: path.join(__dirname, 'eslintrc.json')
+		configFile: path.join(__dirname, 'eslintrc.json'),
+		parser: "babel-eslint"
 	},
 	formatter: 'Formatting is no longer included with standard. Install it separately: "npm install -g happiness-format"',
 	homepage: pkg.homepage,


### PR DESCRIPTION
I'm using awaits and async stuff so I needed to use the babel-eslint parser. Maybe someone else will need this as well.
